### PR TITLE
Add CORS rules to existing bucket

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -1,6 +1,6 @@
 import { defineBackend } from "@aws-amplify/backend";
 import { Effect, Policy, PolicyStatement } from "aws-cdk-lib/aws-iam";
-import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Bucket, HttpMethods } from "aws-cdk-lib/aws-s3";
 import { auth } from "./auth/resource";
 // import { storage } from "./storage/resource";
 import { BUCKET_NAME, BUCKET_REGION } from "../amplify-config";
@@ -21,6 +21,12 @@ const customBucket = Bucket.fromBucketAttributes(
     region: BUCKET_REGION,
   }
 );
+
+customBucket.addCorsRule({
+  allowedMethods: [HttpMethods.GET, HttpMethods.PUT, HttpMethods.DELETE],
+  allowedOrigins: ["*"],
+  allowedHeaders: ["*"],
+});
 
 backend.addOutput({
   storage: {


### PR DESCRIPTION
## Summary
- configure S3 bucket imported by CDK with CORS rules

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: cannot find module 'react' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6840990025d8832cb854a5e03b312c48