### PR TITLE
Add auditor group trigger

### DIFF
--- a/amplify/auth/add-to-auditor.ts
+++ b/amplify/auth/add-to-auditor.ts
@@ -1,0 +1,17 @@
+import { CognitoIdentityProviderClient, AdminAddUserToGroupCommand } from "@aws-sdk/client-cognito-identity-provider";
+import { Handler } from "aws-lambda";
+
+export const handler: Handler = async (event) => {
+  const client = new CognitoIdentityProviderClient({});
+  const { userPoolId, userName } = event;
+  if (typeof userPoolId === "string" && typeof userName === "string") {
+    await client.send(
+      new AdminAddUserToGroupCommand({
+        UserPoolId: userPoolId,
+        Username: userName,
+        GroupName: "auditor",
+      })
+    );
+  }
+  return event;
+};

--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -4,6 +4,8 @@ import { SAML_METADATA_URL, AMPLIFY_URL } from "../../amplify-config";
 const addToAuditor = defineFunction({
   entry: "./add-to-auditor.ts",
 });
+// When used in the triggers below, this function is automatically provisioned as
+// part of the auth resource; no extra import in backend.ts is required.
 
 /**
  * Define and configure your auth resource

--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -1,5 +1,9 @@
-import { defineAuth } from "@aws-amplify/backend";
+import { defineAuth, defineFunction } from "@aws-amplify/backend";
 import { SAML_METADATA_URL, AMPLIFY_URL } from "../../amplify-config";
+
+const addToAuditor = defineFunction({
+  entry: "./add-to-auditor.ts",
+});
 
 /**
  * Define and configure your auth resource
@@ -25,4 +29,7 @@ export const auth = defineAuth({
     },
   },
   groups: ["admin", "auditor"],
+  triggers: {
+    postConfirmation: addToAuditor,
+  },
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@aws-amplify/ui-react": "^6.9.1",
     "@aws-amplify/ui-react-storage": "^3.8.0",
     "aws-amplify": "^6.13.1",
+    "@aws-sdk/client-cognito-identity-provider": "^3.548.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
## Summary
- create a post-confirmation Lambda function that assigns users to the `auditor` group
- register the new function as a trigger in the auth resource

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6840bb28a080832cbe83686623e4b292