### PR TITLE
Fix invalid attribute mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ User sign-up requests include an Azure Active Directory group claim. The
 post-confirmation Lambda adds each user to the corresponding Cognito group so
 permissions mirror their Azure AD assignments.
 
+The Cognito user pool defines a custom attribute `azure_group`. During SAML
+sign-in this attribute is populated from the Azure AD groups claim and later
+used by the post-confirmation function to place the user in the matching group.
+
 ## Deploying to AWS
 
 For detailed instructions on deploying your application, refer to the [deployment section](https://docs.amplify.aws/react/start/quickstart/#deploy-a-fullstack-app-to-aws) of our documentation.

--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -29,6 +29,11 @@ export const auth = defineAuth({
       logoutUrls: [AMPLIFY_URL + "/logout/"],
     },
   },
+  userAttributes: {
+    custom: {
+      azure_group: { type: "string", mutable: true },
+    },
+  },
   groups: ["admin", "auditor"],
   triggers: {
     postConfirmation: postAuthHandler,


### PR DESCRIPTION
## Summary
- map Azure AD groups to Cognito by adding a custom `azure_group` attribute
- document the `azure_group` attribute in the README

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_6849639920e0832ca4830c985c6431c7